### PR TITLE
Hack to make oidc-client-js work with azure common tenant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9020,6 +9020,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "kdbush": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "core-js": "^3.6.4",
     "deck.gl": "^8.0.0",
     "http-proxy-middleware": "^1.0.3",
+    "jwt-decode": "^2.2.0",
     "mjolnir.js": "^2.4.0",
+    "oidc-client": "^1.10.1",
     "prop-types": "15.7.2",
     "qs": "^6.9.1",
     "@svgdotjs/svg.js": "^3.0.12",
@@ -24,11 +26,10 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
+    "react-virtualized": "^9.21.2",
     "react-window": "^1.8.5",
     "redux": "^4.0.5",
-    "typeface-roboto": "0.0.75",
-    "oidc-client": "^1.10.1",
-    "react-virtualized": "^9.21.2"
+    "typeface-roboto": "0.0.75"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/utils/authentication/AuthService.js
+++ b/src/utils/authentication/AuthService.js
@@ -14,7 +14,6 @@ if (process.env.REACT_APP_USE_AUTHENTICATION === "true") {
     userManagerPromise = fetch('idpSettings.json')
         .then(r => r.json())
         .then(idpSettings => {
-
             /* hack to ignore the iss check. XXX TODO to remove */
             const regextoken=/id_token=[^&]*/;
             const regexstate=/state=[^&]*/;
@@ -24,12 +23,11 @@ if (process.env.REACT_APP_USE_AUTHENTICATION === "true") {
                 authority = jwtDecode(id_token).iss
                 const state=window.location.hash.match(regexstate)[0].split('=')[1];
                 const strState = localStorage.getItem("oidc." + state);
-                console.log(strState);
                 const storedState = JSON.parse(strState);
                 storedState.authority=authority;
-                localStorage.setItem("oidc." + state, storedState);
-            };
-            authority = authority || idpSettings.authority
+                localStorage.setItem("oidc." + state, JSON.stringify(storedState));
+            }
+            authority = authority || idpSettings.authority;
 
             let settings = {
                 authority,


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When using the common azure tenant, oidc-client-js refuses the token because the issuer is not the same


**What is the new behavior (if this is a feature change)?**
don't refuse the token


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
