### PR TITLE
fix click on substation text displaying an error voltage level diagram

### DIFF
--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -132,7 +132,9 @@ const NetworkMap = (props) => {
     }
 
     function onClickHandler(info) {
-        if (info.layer && info.layer.id.startsWith(SUBSTATION_LAYER_PREFIX)) {
+        if (info.layer && info.layer.id.startsWith(SUBSTATION_LAYER_PREFIX)
+         && info.object && info.object.substationId // is a voltage level marker, not a substation text
+        ) {
             if (props.onSubstationClick) {
                 props.onSubstationClick(info.object.id)
             }


### PR DESCRIPTION
When clicking on a substation label, an error svg is displayed:
![Capture d’écran de 2020-04-09 14-24-20](https://user-images.githubusercontent.com/89208/78894714-df06a500-7a6d-11ea-92be-8b6451fb5e3a.png)


Signed-off-by: Jon Harper <jon.harper87@gmail.com>