### PR TITLE
Fix map tiles flicker

### DIFF
--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -195,7 +195,6 @@ const NetworkMap = (props) => {
                    controller={{ doubleClickZoom: false }}
                    ContextProvider={MapContext.Provider}>
             <StaticMap
-                reuseMaps
                 mapStyle={ theme.mapboxStyle }
                 preventStyleDiffing={true}
                 mapboxApiAccessToken={MAPBOX_TOKEN}>

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -65,7 +65,7 @@ const StudyNotFound = (props) => {
     );
 };
 
-const INITIAL_POSITION = [2.5, 46.6];
+const INITIAL_POSITION = [0, 0];
 
 const StudyPane = () => {
 
@@ -212,7 +212,7 @@ const StudyPane = () => {
                                     geoData={geoData}
                                     labelsZoomThreshold={8}
                                     initialPosition={INITIAL_POSITION}
-                                    initialZoom={6}
+                                    initialZoom={1}
                                     filteredNominalVoltages={filteredNominalVoltages}
                                     centeredSubstationId={focusedVoltageLevel && focusedVoltageLevel.substationId}
                                     onSubstationClick={showVoltageLevelDiagram} />


### PR DESCRIPTION
Because of reuseMaps options of mapbox, we do not have the same "visual aspect" of study opening. When we open the second study, first map appears as it was in the previous study then it is reinitialized.
Also before data loading (network + geo data) we display the map at the lower zoom level (whole world), before zoom once data have loaded.

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>