### PR TITLE
Fix IEEE CDF logo for powsybl <= 3.1

### DIFF
--- a/src/components/study-manager.js
+++ b/src/components/study-manager.js
@@ -102,6 +102,7 @@ const StudyCard = ({study, onClick}) => {
             case 'UCTE':
                 return <UcteLogo className={classes.logo}/>;
             case 'IEEE-CDF':
+            case 'IEEE CDF': // for powsybl <= 3.1 compatibility
                 return <IeeeLogo className={classes.logo}/>;
             default:
                 break;


### PR DESCRIPTION
Case format for IEEE CDF converter was 'IEEE CDF' and not 'IEEE-CDF' in powsybl <= 3.1. Starting from powsybl 3.2 it is 'IEEE-CDF'

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>