### PR TITLE
Add topological coloring to parameters

### DIFF
--- a/src/components/parameters.js
+++ b/src/components/parameters.js
@@ -11,8 +11,6 @@ import {FormattedMessage} from "react-intl";
 
 import {useDispatch, useSelector} from "react-redux";
 
-import {useHistory} from "react-router-dom";
-
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Container from "@material-ui/core/Container";
@@ -25,7 +23,15 @@ import RadioGroup from "@material-ui/core/RadioGroup";
 import Switch from "@material-ui/core/Switch";
 import Typography from "@material-ui/core/Typography";
 
-import {DARK_THEME, LIGHT_THEME, selectTheme, toggleUseNameState, toggleCenterLabelState, toggleDiagonalLabelState} from "../redux/actions";
+import {
+    DARK_THEME,
+    LIGHT_THEME,
+    selectTheme,
+    toggleCenterLabelState,
+    toggleDiagonalLabelState,
+    toggleTopologicalColoringState,
+    toggleUseNameState
+} from "../redux/actions";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import Dialog from "@material-ui/core/Dialog";
@@ -56,6 +62,7 @@ const Parameters = ({showParameters, hideParameters}) => {
     const useName = useSelector(state => state.useName);
     const centerLabel = useSelector(state => state.centerLabel);
     const diagonalLabel = useSelector(state => state.diagonalLabel);
+    const topologicalColoring = useSelector(state => state.topologicalColoring);
     const [tabIndex, setTabIndex] = React.useState(0);
 
     const theme = useSelector(state => state.theme);
@@ -139,6 +146,8 @@ const Parameters = ({showParameters, hideParameters}) => {
                     {MakeSwitch(diagonalLabel, "diagonalLabel", () => dispatch(toggleDiagonalLabelState()))}
                     <MakeLineSeparator/>
                     {MakeSwitch(centerLabel, "centerLabel", () => dispatch(toggleCenterLabelState()))}
+                    <MakeLineSeparator/>
+                    {MakeSwitch(topologicalColoring, "topologicalColoring", () => dispatch(toggleTopologicalColoringState()))}
                 </Grid>
             )
     }

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -81,6 +81,8 @@ const StudyPane = () => {
 
     const diagonalName = useSelector( state => state.diagonalLabel);
 
+    const topologicalColoring = useSelector( state => state.topologicalColoring);
+
     const [studyNotFound, setStudyNotFound] = useState(false);
 
     const [displayedVoltageLevelId, setDisplayedVoltageLevelId] = useState(null);
@@ -229,7 +231,7 @@ const StudyPane = () => {
                                 <SingleLineDiagram onClose={() => closeVoltageLevelDiagram()}
                                                    onNextVoltageLevelClick={showVoltageLevelDiagram}
                                                    diagramTitle={useName && displayedVoltageLevel ? displayedVoltageLevel.name : displayedVoltageLevelId}
-                                                   svgUrl={getVoltageLevelSingleLineDiagram(studyName, displayedVoltageLevelId, useName, centerName, diagonalName)} />
+                                                   svgUrl={getVoltageLevelSingleLineDiagram(studyName, displayedVoltageLevelId, useName, centerName, diagonalName, topologicalColoring)} />
                             </div>
                         }
                         {

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -97,6 +97,12 @@ export function toggleDiagonalLabelState() {
     return { type: DIAGONAL_LABEL };
 }
 
+export const TOPOLOGICAL_COLORING = 'TOPOLOGICAL_COLORING';
+
+export function toggleTopologicalColoringState() {
+    return { type: TOPOLOGICAL_COLORING };
+}
+
 export const SIGNIN_CALLBACK_ERROR = 'SIGNIN_CALLBACK_ERROR';
 
 export function setSignInCallbackError(signInCallbackError) {

--- a/src/redux/local-storage.js
+++ b/src/redux/local-storage.js
@@ -49,3 +49,14 @@ export const getLocalStorageDiagonalLabel = () => {
 export const saveLocalStorageDiagonalLabel = (useName) => {
     localStorage.setItem(LOCAL_STORAGE_DIAGONAL_LABEL_KEY, useName);
 };
+
+const LOCAL_STORAGE_TOPOLOGICAL_COLORING_KEY = "STUDY_APP_TOPOLOGICAL_COLORING";
+
+export const getLocalStorageTopologicalColoring = () => {
+    const value = localStorage.getItem(LOCAL_STORAGE_TOPOLOGICAL_COLORING_KEY);
+    return value === "true";
+};
+
+export const saveLocalStorageTopologicalColoring = (topologicalColoring) => {
+    localStorage.setItem(LOCAL_STORAGE_TOPOLOGICAL_COLORING_KEY, topologicalColoring);
+};

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -11,10 +11,12 @@ import {
     getLocalStorageCenterLabel,
     getLocalStorageDiagonalLabel,
     getLocalStorageTheme,
+    getLocalStorageTopologicalColoring,
     getLocalStorageUseName,
     saveLocalStorageCenterLabel,
     saveLocalStorageDiagonalLabel,
     saveLocalStorageTheme,
+    saveLocalStorageTopologicalColoring,
     saveLocalStorageUseName
 } from "./local-storage";
 
@@ -32,6 +34,7 @@ import {
     SELECT_CASE,
     SELECT_FILE,
     SELECT_THEME,
+    TOPOLOGICAL_COLORING,
     USE_NAME,
     USER,
     SIGNIN_CALLBACK_ERROR
@@ -50,6 +53,7 @@ const initialState = {
     user : null,
     centerLabel : getLocalStorageCenterLabel(),
     diagonalLabel : getLocalStorageDiagonalLabel(),
+    topologicalColoring : getLocalStorageTopologicalColoring(),
     signInCallbackError : null
 };
 
@@ -119,6 +123,11 @@ export const reducer = createReducer(initialState, {
     [DIAGONAL_LABEL]: (state) => {
         state.diagonalLabel = !state.diagonalLabel;
         saveLocalStorageDiagonalLabel(state.diagonalLabel);
+    },
+
+    [TOPOLOGICAL_COLORING]: (state) => {
+        state.topologicalColoring = !state.topologicalColoring;
+        saveLocalStorageTopologicalColoring(state.topologicalColoring);
     },
 
     [SIGNIN_CALLBACK_ERROR]: (state, action) => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -34,6 +34,7 @@
   "useName": "Use the name instead of the identifier",
   "diagonalLabel": "Display name diagonally",
   "centerLabel": "Center name",
+  "topologicalColoring": "Topological coloring",
   "General": "General",
   "SingleLineDiagram": "Single line diagram",
 

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -33,6 +33,7 @@
   "useName": "Utiliser le nom à la place de l'identifiant",
   "diagonalLabel": "Afficher les noms en diagonal",
   "centerLabel": "Centrer les noms",
+  "topologicalColoring": "Coloration topologique",
   "General": "Général",
   "SingleLineDiagram": "Schéma unifilaire",
 

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -21,10 +21,10 @@ export function fetchCases() {
         .then(response => response.json());
 }
 
-export function getVoltageLevelSingleLineDiagram(studyName, voltageLevelId, useName, centerLabel, diagonalLabel) {
+export function getVoltageLevelSingleLineDiagram(studyName, voltageLevelId, useName, centerLabel, diagonalLabel, topologicalColoring) {
     console.info(`Getting url of voltage level diagram '${voltageLevelId}' of study '${studyName}'...`);
     return process.env.REACT_APP_API_STUDY_SERVER + "/v1/studies/" + studyName + "/network/voltage-levels/" + voltageLevelId + "/svg-and-metadata?useName=" + useName
-        + "&centerLabel=" + centerLabel + "&diagonalLabel=" + diagonalLabel;
+        + "&centerLabel=" + centerLabel + "&diagonalLabel=" + diagonalLabel + "&topologicalColoring=" + topologicalColoring;
 }
 
 export function fetchSvg(svgUrl) {


### PR DESCRIPTION
Topological coloring of single line diagram is available in single line diagram server. This PR add a parameter in the "Single line diagram" tab to activate topological coloring instead of default nominal voltage coloring.

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>