### PR TITLE
Refactor the study-app manager

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -133,7 +133,7 @@ const App = () => {
                 { user !== null ? (
                         <Switch>
                             <Route exact path="/">
-                                <StudyManager onStudyClick={name => studyClickHandler(name)}/>
+                                <StudyManager onClick={name => studyClickHandler(name)}/>
                             </Route>
                             <Route exact path="/studies/:studyName">
                                 <StudyPane/>

--- a/src/components/create-study-form.js
+++ b/src/components/create-study-form.js
@@ -197,13 +197,19 @@ export const CreateStudyForm = () => {
             });
     };
 
+    const handleKeyPressed = (event) => {
+        if (event.key === "Enter") {
+            handleCreateNewStudy();
+        }
+    };
+
     return (
         <div>
             <CardActionArea className={classes.addButtonArea} onClick={() => handleClickOpenDialog()}>
                 <AddIcon className={classes.addIcon} />
             </CardActionArea>
 
-            <Dialog open={open} onClose={handleCloseDialog} aria-labelledby="form-dialog-title">
+            <Dialog open={open} onClose={handleCloseDialog} aria-labelledby="form-dialog-title" onKeyPress={handleKeyPressed}>
                 <DialogTitle id="form-dialog-title"><FormattedMessage id="addNewStudy"/></DialogTitle>
                 <DialogContent>
                     <DialogContentText>
@@ -230,7 +236,6 @@ export const CreateStudyForm = () => {
                     />
                     <TextField
                         onChange={(e) => handleStudyDescriptionChanges(e)}
-                        autoFocus
                         margin="dense"
                         value={studyDescription}
                         type="text"
@@ -247,10 +252,10 @@ export const CreateStudyForm = () => {
                     }
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={() => handleCloseDialog()} color="primary">
+                    <Button onClick={() => handleCloseDialog()} variant="text">
                         <FormattedMessage id="cancel"/>
                     </Button>
-                    <Button onClick={() => handleCreateNewStudy()} color="primary">
+                    <Button onClick={() => handleCreateNewStudy()} variant="outlined">
                         <FormattedMessage id="create"/>
                     </Button>
                 </DialogActions>

--- a/src/components/study-manager.js
+++ b/src/components/study-manager.js
@@ -284,11 +284,7 @@ const StudyCard = ({study, onClick}) => {
                 </Collapse>
             </Card>
             <DeleteDialog open={openDeleteDialog} onClose={handleCloseDelete} onClick={handleClickDelete} />
-            <RenameDialog studyName={study.studyName}
-                          openRenameDialog={openRenameDialog}
-                          handleCloseDialog={handleCloseRename}
-                          handleCancel={handleCloseRename}
-                          handleConfirm={handleClickRename}/>
+            <RenameDialog open={openRenameDialog} onClose={handleCloseRename} onClick={handleClickRename} studyName={study.studyName} />
         </div>
     );
 };
@@ -339,7 +335,7 @@ const RenameDialog = (props) => {
 
     const handleClick = () => {
         console.debug("newStudyName : " + newStudyNameValue);
-        props.handleConfirm(newStudyNameValue);
+        props.onClick(newStudyNameValue);
     };
 
     const handleExited = () => {
@@ -347,14 +343,14 @@ const RenameDialog = (props) => {
     };
 
     return (
-        <Dialog open={props.openRenameDialog} onClose={props.handleCloseDialog} onExited={handleExited} aria-labelledby="dialog-title-rename">
+        <Dialog open={props.open} onClose={props.onClose} onExited={handleExited} aria-labelledby="dialog-title-rename">
             <DialogTitle id="dialog-title-rename"><FormattedMessage id="renameStudy"/></DialogTitle>
             <DialogContent>
                 <InputLabel htmlFor="newStudyName"><FormattedMessage id="renameStudyMsg"/></InputLabel>
                 <TextField id="newStudyName" value={newStudyNameValue} required={true} onChange={updateStudyNameValue} />
             </DialogContent>
             <DialogActions>
-                <Button onClick={props.handleCancel} color="primary">
+                <Button onClick={props.onClose} color="primary">
                     <FormattedMessage id="cancel"/>
                 </Button>
                 <Button onClick={handleClick} color="primary">
@@ -363,6 +359,13 @@ const RenameDialog = (props) => {
             </DialogActions>
         </Dialog>
     );
+};
+
+RenameDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
+    studyName: PropTypes.string.isRequired,
 };
 
 const StudyManager = ({onStudyClick}) => {

--- a/src/components/study-manager.js
+++ b/src/components/study-manager.js
@@ -6,6 +6,7 @@
  */
 
 import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
 import {useDispatch, useSelector} from "react-redux";
 
 import {FormattedMessage} from "react-intl";
@@ -92,8 +93,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const StudyCard = ({study, onClick}) => {
-    const [openDeleteDialog, setOpenDelete] = React.useState(false);
-    const [openRenameDialog, setOpenRename]  = React.useState(false);
+
     const dispatch = useDispatch();
     const classes = useStyles();
 
@@ -133,22 +133,32 @@ const StudyCard = ({study, onClick}) => {
         />
     ));
 
+    // ########################################################################
+    // ### Action menu ########################################################
+    // ########################################################################
+
     const [anchorEl, setAnchorEl] = React.useState(null);
 
-    const handleClick = event => {
+    const handleOpenMenu = event => {
         setAnchorEl(event.currentTarget);
     };
 
-    const handleClose = () => {
+    const handleCloseMenu = () => {
         setAnchorEl(null);
     };
 
-    const handleDeleteStudy = () => {
+    // ########################################################################
+    // ### Delete study #######################################################
+    // ########################################################################
+
+    const [openDeleteDialog, setOpenDelete] = React.useState(false);
+
+    const handleOpenDelete = () => {
         setAnchorEl(null);
         setOpenDelete(true);
     };
 
-    const handleDeleteStudyConfirmed = () => {
+    const handleClickDelete = () => {
         deleteStudy(study.studyName).then(() => {
             fetchStudies().then(studies => {
                 dispatch(loadStudiesSuccess(studies));
@@ -156,20 +166,22 @@ const StudyCard = ({study, onClick}) => {
         });
     };
 
-    const handleCloseDeleteDialog = () => {
+    const handleCloseDelete = () => {
         setOpenDelete(false);
     };
 
-    const handleCancelDelete = () => {
-        setOpenDelete(false);
-    };
+    // ########################################################################
+    // ### Rename study #######################################################
+    // ########################################################################
 
-    const handleRenameStudy = () => {
+    const [openRenameDialog, setOpenRename]  = React.useState(false);
+
+    const handleOpenRename = () => {
         setAnchorEl(null);
         setOpenRename(true);
     };
 
-    const handleRenameStudyConfirmed = (newStudyNameValue) => {
+    const handleClickRename = (newStudyNameValue) => {
         renameStudy(study.studyName, newStudyNameValue)
             .then(() => {
                 fetchStudies().then(studies => {
@@ -179,13 +191,12 @@ const StudyCard = ({study, onClick}) => {
             });
     };
 
-    const handleCancelRename = () => {
+    const handleCloseRename = () => {
         setOpenRename(false);
     };
 
-    const handleCloseRenameDialog = () => {
-        setOpenRename(false);
-    };
+    // ########################################################################
+    // ########################################################################
 
     const [expanded, setExpanded] = React.useState(false);
 
@@ -228,7 +239,7 @@ const StudyCard = ({study, onClick}) => {
                                 aria-controls="case-menu"
                                 aria-haspopup="true"
                                 variant="contained"
-                                onClick={handleClick}
+                                onClick={handleOpenMenu}
                     >
                         <MoreVertIcon />
                     </IconButton>
@@ -237,16 +248,16 @@ const StudyCard = ({study, onClick}) => {
                         anchorEl={anchorEl}
                         keepMounted
                         open={Boolean(anchorEl)}
-                        onClose={handleClose}
+                        onClose={handleCloseMenu}
                     >
-                        <MenuItem onClick={handleDeleteStudy}>
+                        <MenuItem onClick={handleOpenDelete}>
                             <ListItemIcon>
                                 <DeleteIcon fontSize="small" />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="delete"/>} />
                         </MenuItem>
 
-                        <MenuItem onClick={handleRenameStudy}>
+                        <MenuItem onClick={handleOpenRename}>
                             <ListItemIcon>
                                 <EditIcon fontSize="small"/>
                             </ListItemIcon>
@@ -272,29 +283,50 @@ const StudyCard = ({study, onClick}) => {
                     </CardContent>
                 </Collapse>
             </Card>
-            <Dialog open={openDeleteDialog} onClose={handleCloseDeleteDialog} aria-labelledby="dialog-title-delete">
-                <DialogTitle id="dialog-title-delete"><FormattedMessage id="deleteStudy"/></DialogTitle>
-                <DialogContent>
-                    <DialogContentText>
-                        <FormattedMessage id="deleteStudyMsg"/>
-                    </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleCancelDelete} color="primary">
-                        <FormattedMessage id="cancel"/>
-                    </Button>
-                    <Button onClick={handleDeleteStudyConfirmed} color="primary">
-                        <FormattedMessage id="delete"/>
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <DeleteDialog open={openDeleteDialog} onClose={handleCloseDelete} onClick={handleClickDelete} />
             <RenameDialog studyName={study.studyName}
                           openRenameDialog={openRenameDialog}
-                          handleCloseDialog={handleCloseRenameDialog}
-                          handleCancel={handleCancelRename}
-                          handleConfirm={handleRenameStudyConfirmed}/>
+                          handleCloseDialog={handleCloseRename}
+                          handleCancel={handleCloseRename}
+                          handleConfirm={handleClickRename}/>
         </div>
     );
+};
+
+const DeleteDialog = (props) => {
+
+    const handleClose = () => {
+        props.onClose();
+    };
+
+    const handleClick = () => {
+        props.onClick();
+    };
+
+    return (
+        <Dialog open={props.open} onClose={handleClose} aria-labelledby="dialog-title-delete">
+            <DialogTitle id="dialog-title-delete"><FormattedMessage id="deleteStudy"/></DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    <FormattedMessage id="deleteStudyMsg"/>
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose} color="primary">
+                    <FormattedMessage id="cancel"/>
+                </Button>
+                <Button onClick={handleClick} color="primary">
+                    <FormattedMessage id="delete"/>
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+DeleteDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
 };
 
 const RenameDialog = (props) => {
@@ -319,7 +351,7 @@ const RenameDialog = (props) => {
             <DialogTitle id="dialog-title-rename"><FormattedMessage id="renameStudy"/></DialogTitle>
             <DialogContent>
                 <InputLabel htmlFor="newStudyName"><FormattedMessage id="renameStudyMsg"/></InputLabel>
-                <TextField id="newStudyName" value={newStudyNameValue} required={true} onChange={updateStudyNameValue}></TextField>
+                <TextField id="newStudyName" value={newStudyNameValue} required={true} onChange={updateStudyNameValue} />
             </DialogContent>
             <DialogActions>
                 <Button onClick={props.handleCancel} color="primary">

--- a/src/components/study-manager.js
+++ b/src/components/study-manager.js
@@ -347,7 +347,7 @@ const StudyManager = ({ onClick }) => {
 };
 
 StudyManager.propTypes = {
-    onStudyClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
 };
 
 export default StudyManager;

--- a/src/components/study-manager.js
+++ b/src/components/study-manager.js
@@ -92,7 +92,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const StudyCard = ({study, onClick}) => {
+const StudyCard = ({ study, onClick }) => {
 
     const dispatch = useDispatch();
     const classes = useStyles();
@@ -220,7 +220,7 @@ const StudyCard = ({study, onClick}) => {
                             </div>
                         }
                         subheader={
-                            study.caseDate
+                            study.caseDate && study.caseDate.toLocaleString()
                         }
                     />
                 </CardActionArea>
@@ -289,6 +289,16 @@ const StudyCard = ({study, onClick}) => {
     );
 };
 
+StudyCard.propTypes = {
+    study: PropTypes.shape({
+        studyName: PropTypes.string.isRequired,
+        caseFormat: PropTypes.string,
+        description: PropTypes.string,
+        caseDate: PropTypes.instanceOf(Date),
+    }),
+    onClick: PropTypes.func.isRequired,
+};
+
 const DeleteDialog = (props) => {
 
     const handleClose = () => {
@@ -296,6 +306,7 @@ const DeleteDialog = (props) => {
     };
 
     const handleClick = () => {
+        console.debug("Request for case deletion");
         props.onClick();
     };
 
@@ -334,23 +345,27 @@ const RenameDialog = (props) => {
     };
 
     const handleClick = () => {
-        console.debug("newStudyName : " + newStudyNameValue);
+        console.debug("Request for case renaming : " + props.studyName + " => " + newStudyNameValue);
         props.onClick(newStudyNameValue);
     };
+
+    const handleClose = () => {
+        props.onClose();
+    }
 
     const handleExited = () => {
         setNewStudyNameValue(props.studyName);
     };
 
     return (
-        <Dialog open={props.open} onClose={props.onClose} onExited={handleExited} aria-labelledby="dialog-title-rename">
+        <Dialog open={props.open} onClose={handleClose} onExited={handleExited} aria-labelledby="dialog-title-rename">
             <DialogTitle id="dialog-title-rename"><FormattedMessage id="renameStudy"/></DialogTitle>
             <DialogContent>
                 <InputLabel htmlFor="newStudyName"><FormattedMessage id="renameStudyMsg"/></InputLabel>
                 <TextField id="newStudyName" value={newStudyNameValue} required={true} onChange={updateStudyNameValue} />
             </DialogContent>
             <DialogActions>
-                <Button onClick={props.onClose} color="primary">
+                <Button onClick={handleClose} color="primary">
                     <FormattedMessage id="cancel"/>
                 </Button>
                 <Button onClick={handleClick} color="primary">
@@ -368,7 +383,7 @@ RenameDialog.propTypes = {
     studyName: PropTypes.string.isRequired,
 };
 
-const StudyManager = ({onStudyClick}) => {
+const StudyManager = ({ onStudyClick }) => {
     const dispatch = useDispatch();
 
     useEffect(() => {
@@ -401,6 +416,10 @@ const StudyManager = ({onStudyClick}) => {
             </Grid>
         </Container>
     );
+};
+
+StudyManager.propTypes = {
+    onStudyClick: PropTypes.func.isRequired,
 };
 
 export default StudyManager;

--- a/src/components/study-manager.js
+++ b/src/components/study-manager.js
@@ -9,7 +9,7 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {useDispatch, useSelector} from "react-redux";
 
-import {FormattedMessage} from "react-intl";
+import {FormattedMessage, useIntl} from "react-intl";
 import {makeStyles} from "@material-ui/core/styles";
 import Typography from '@material-ui/core/Typography';
 import Card from '@material-ui/core/Card';
@@ -282,15 +282,15 @@ const StudyCard = ({ study, onClick }) => {
                 open={openDeleteDialog}
                 onClose={handleCloseDelete}
                 onClick={handleClickDelete}
-                title={<FormattedMessage id="deleteStudy" />}
-                message={<FormattedMessage id="deleteStudyMsg" />}
+                title={useIntl().formatMessage({id: "deleteStudy"})}
+                message={useIntl().formatMessage({id: "deleteStudyMsg"})}
             />
             <RenameDialog
                 open={openRenameDialog}
                 onClose={handleCloseRename}
                 onClick={handleClickRename}
-                title={<FormattedMessage id="renameStudy" />}
-                message={<FormattedMessage id="renameStudyMsg" />}
+                title={useIntl().formatMessage({id: "renameStudy"})}
+                message={useIntl().formatMessage({id: "renameStudyMsg"})}
                 currentName={study.studyName}
             />
         </div>

--- a/src/utils/dialogs.js
+++ b/src/utils/dialogs.js
@@ -18,6 +18,17 @@ import InputLabel from "@material-ui/core/InputLabel";
 import TextField from "@material-ui/core/TextField";
 
 /**
+ * Concatenate one or more elements to generate a contextual id
+ * @param stringList
+ * @returns {string}
+ */
+const createId = (...stringList) => {
+    return stringList.map((value) => {
+        return value.replace(/\W+/g, '-').toLowerCase();
+    }).join('-');
+}
+
+/**
  * Dialog to delete an element #TODO To be moved in the common-ui repository once it has been created
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
@@ -43,8 +54,8 @@ const DeleteDialog = ({ open, onClose, onClick, title, message }) => {
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} aria-labelledby="dialog-title-delete" onKeyPress={handleKeyPressed}>
-            <DialogTitle id="dialog-title-delete">{title}</DialogTitle>
+        <Dialog open={open} onClose={handleClose} aria-labelledby={createId(title)} onKeyPress={handleKeyPressed}>
+            <DialogTitle id={createId(title)}>{title}</DialogTitle>
             <DialogContent>
                 <DialogContentText>{message}</DialogContentText>
             </DialogContent>
@@ -60,8 +71,8 @@ DeleteDialog.propTypes = {
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
-    title: PropTypes.object.isRequired,
-    message: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
 };
 
 /**
@@ -105,11 +116,11 @@ const RenameDialog = ({ open, onClose, onClick, title, message, currentName }) =
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby="dialog-title-rename" onKeyPress={handleKeyPressed}>
-            <DialogTitle id="dialog-title-rename">{title}</DialogTitle>
+        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby={createId(title)} onKeyPress={handleKeyPressed}>
+            <DialogTitle id={createId(title)}>{title}</DialogTitle>
             <DialogContent>
-                <InputLabel htmlFor="newName">{message}</InputLabel>
-                <TextField autoFocus id="newName" value={newNameValue} required={true} onChange={updateNameValue}  />
+                <InputLabel htmlFor={createId(title, "newName")}>{message}</InputLabel>
+                <TextField autoFocus id={createId(title, "newName")} value={newNameValue} required={true} onChange={updateNameValue}  />
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose} variant="text"><FormattedMessage id="cancel" /></Button>
@@ -123,8 +134,8 @@ RenameDialog.propTypes = {
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
-    title: PropTypes.object.isRequired,
-    message: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
     currentName: PropTypes.string.isRequired,
 };
 

--- a/src/utils/dialogs.js
+++ b/src/utils/dialogs.js
@@ -36,15 +36,21 @@ const DeleteDialog = ({ open, onClose, onClick, title, message }) => {
         onClick();
     };
 
+    const handleKeyPressed = (event) => {
+        if (open && event.key === "Enter") {
+            handleClose();
+        }
+    };
+
     return (
-        <Dialog open={open} onClose={handleClose} aria-labelledby="dialog-title-delete">
+        <Dialog open={open} onClose={handleClose} aria-labelledby="dialog-title-delete" onKeyPress={handleKeyPressed}>
             <DialogTitle id="dialog-title-delete">{title}</DialogTitle>
             <DialogContent>
                 <DialogContentText>{message}</DialogContentText>
             </DialogContent>
             <DialogActions>
-                <Button onClick={handleClose} color="primary"><FormattedMessage id="cancel" /></Button>
-                <Button onClick={handleClick} color="primary"><FormattedMessage id="delete" /></Button>
+                <Button onClick={handleClose} variant="outlined"><FormattedMessage id="cancel" /></Button>
+                <Button onClick={handleClick} variant="text"><FormattedMessage id="delete" /></Button>
             </DialogActions>
         </Dialog>
     )
@@ -76,8 +82,12 @@ const RenameDialog = ({ open, onClose, onClick, title, message, currentName }) =
     };
 
     const handleClick = () => {
-        console.debug("Request for renaming : " + currentName + " => " + newNameValue);
-        onClick(newNameValue);
+        if (currentName !== newNameValue) {
+            console.debug("Request for renaming : " + currentName + " => " + newNameValue);
+            onClick(newNameValue);
+        } else {
+            handleClose();
+        }
     };
 
     const handleClose = () => {
@@ -88,16 +98,22 @@ const RenameDialog = ({ open, onClose, onClick, title, message, currentName }) =
         setNewNameValue(currentName);
     };
 
+    const handleKeyPressed = (event) => {
+        if (open && event.key === "Enter") {
+            handleClick();
+        }
+    };
+
     return (
-        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby="dialog-title-rename">
+        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby="dialog-title-rename" onKeyPress={handleKeyPressed}>
             <DialogTitle id="dialog-title-rename">{title}</DialogTitle>
             <DialogContent>
                 <InputLabel htmlFor="newName">{message}</InputLabel>
-                <TextField id="newName" value={newNameValue} required={true} onChange={updateNameValue}  />
+                <TextField autoFocus id="newName" value={newNameValue} required={true} onChange={updateNameValue}  />
             </DialogContent>
             <DialogActions>
-                <Button onClick={handleClose} color="primary"><FormattedMessage id="cancel" /></Button>
-                <Button onClick={handleClick} color="primary"><FormattedMessage id="rename" /></Button>
+                <Button onClick={handleClose} variant="text"><FormattedMessage id="cancel" /></Button>
+                <Button onClick={handleClick} variant="outlined"><FormattedMessage id="rename"  /></Button>
             </DialogActions>
         </Dialog>
     );

--- a/src/utils/dialogs.js
+++ b/src/utils/dialogs.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import {FormattedMessage} from "react-intl";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogActions from "@material-ui/core/DialogActions";
+import Button from "@material-ui/core/Button";
+import PropTypes from "prop-types";
+import React from "react";
+import InputLabel from "@material-ui/core/InputLabel";
+import TextField from "@material-ui/core/TextField";
+
+/**
+ * Dialog to delete an element #TODO To be moved in the common-ui repository once it has been created
+ * @param {Boolean} open Is the dialog open ?
+ * @param {EventListener} onClose Event to close the dialog
+ * @param {EventListener} onClick Event to submit the deletion
+ * @param {String} title Title of the dialog
+ * @param {String} message Message of the dialog
+ */
+const DeleteDialog = ({ open, onClose, onClick, title, message }) => {
+
+    const handleClose = () => {
+        onClose();
+    };
+
+    const handleClick = () => {
+        console.debug("Request for deletion");
+        onClick();
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} aria-labelledby="dialog-title-delete">
+            <DialogTitle id="dialog-title-delete">{title}</DialogTitle>
+            <DialogContent>
+                <DialogContentText>{message}</DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose} color="primary"><FormattedMessage id="cancel" /></Button>
+                <Button onClick={handleClick} color="primary"><FormattedMessage id="delete" /></Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+DeleteDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
+    title: PropTypes.object.isRequired,
+    message: PropTypes.object.isRequired,
+};
+
+/**
+ * Dialog to rename an element #TODO To be moved in the common-ui repository once it has been created
+ * @param {Boolean} open Is the dialog open ?
+ * @param {EventListener} onClose Event to close the dialog
+ * @param {EventListener} onClick Event to submit the renaming
+ * @param {String} title Title of the dialog
+ * @param {String} message Message of the dialog
+ * @param {String} currentName Name before renaming
+ */
+const RenameDialog = ({ open, onClose, onClick, title, message, currentName }) => {
+
+    const [newNameValue, setNewNameValue] = React.useState(currentName);
+
+    const updateNameValue= (event) => {
+        setNewNameValue(event.target.value);
+    };
+
+    const handleClick = () => {
+        console.debug("Request for renaming : " + currentName + " => " + newNameValue);
+        onClick(newNameValue);
+    };
+
+    const handleClose = () => {
+        onClose();
+    }
+
+    const handleExited = () => {
+        setNewNameValue(currentName);
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby="dialog-title-rename">
+            <DialogTitle id="dialog-title-rename">{title}</DialogTitle>
+            <DialogContent>
+                <InputLabel htmlFor="newName">{message}</InputLabel>
+                <TextField id="newName" value={newNameValue} required={true} onChange={updateNameValue}  />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose} color="primary"><FormattedMessage id="cancel" /></Button>
+                <Button onClick={handleClick} color="primary"><FormattedMessage id="rename" /></Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+RenameDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
+    title: PropTypes.object.isRequired,
+    message: PropTypes.object.isRequired,
+    currentName: PropTypes.string.isRequired,
+};
+
+export { DeleteDialog, RenameDialog };

--- a/src/utils/dialogs.js
+++ b/src/utils/dialogs.js
@@ -18,17 +18,6 @@ import InputLabel from "@material-ui/core/InputLabel";
 import TextField from "@material-ui/core/TextField";
 
 /**
- * Concatenate one or more elements to generate a contextual id
- * @param stringList
- * @returns {string}
- */
-const createId = (...stringList) => {
-    return stringList.map((value) => {
-        return value.replace(/\W+/g, '-').toLowerCase();
-    }).join('-');
-}
-
-/**
  * Dialog to delete an element #TODO To be moved in the common-ui repository once it has been created
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
@@ -54,8 +43,8 @@ const DeleteDialog = ({ open, onClose, onClick, title, message }) => {
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} aria-labelledby={createId(title)} onKeyPress={handleKeyPressed}>
-            <DialogTitle id={createId(title)}>{title}</DialogTitle>
+        <Dialog open={open} onClose={handleClose} aria-labelledby="dialog-title-delete" onKeyPress={handleKeyPressed}>
+            <DialogTitle>{title}</DialogTitle>
             <DialogContent>
                 <DialogContentText>{message}</DialogContentText>
             </DialogContent>
@@ -116,11 +105,11 @@ const RenameDialog = ({ open, onClose, onClick, title, message, currentName }) =
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby={createId(title)} onKeyPress={handleKeyPressed}>
-            <DialogTitle id={createId(title)}>{title}</DialogTitle>
+        <Dialog open={open} onClose={handleClose} onExited={handleExited} aria-labelledby="dialog-title-rename" onKeyPress={handleKeyPressed}>
+            <DialogTitle>{title}</DialogTitle>
             <DialogContent>
-                <InputLabel htmlFor={createId(title, "newName")}>{message}</InputLabel>
-                <TextField autoFocus id={createId(title, "newName")} value={newNameValue} required={true} onChange={updateNameValue}  />
+                <InputLabel htmlFor="newName">{message}</InputLabel>
+                <TextField autoFocus value={newNameValue} required={true} onChange={updateNameValue}  />
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose} variant="text"><FormattedMessage id="cancel" /></Button>


### PR DESCRIPTION
- [x] Reorganization of the 'handle' functions
- [x] PropTypes validation for each component
- [x] Enter to close/validate the actions
- [x] Handle the warnings
- [x] Extract the 2 dialogs to generalise them