### PR TITLE
Add substation max radius

### DIFF
--- a/src/components/network/layers/scatterplot-layer-ext.js
+++ b/src/components/network/layers/scatterplot-layer-ext.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import {ScatterplotLayer} from "deck.gl";
+import GL from '@luma.gl/constants';
+
+const defaultProps = {
+    getRadiusMaxPixels: {type: 'accessor', value: 1}
+};
+
+/**
+ * An extended scatter plot layer that allows a radius max pixels to be different for each object.
+ */
+export default class ScatterplotLayerExt extends ScatterplotLayer {
+
+    getShaders() {
+        const shaders = super.getShaders();
+        return Object.assign({}, shaders, {
+            vs: shaders.vs.replace(', radiusMaxPixels', ', instanceRadiusMaxPixels'), // hack to replace the uniform variable to corresponding attribute
+            inject: {
+                'vs:#decl': `\
+attribute float instanceRadiusMaxPixels;
+`
+            }
+        });
+    }
+
+    initializeState(params) {
+        super.initializeState(params);
+
+        const attributeManager = this.getAttributeManager();
+        attributeManager.addInstanced({
+            instanceRadiusMaxPixels: {
+                size: 1,
+                transition: true,
+                accessor: 'getRadiusMaxPixels',
+                type: GL.FLOAT,
+                defaultValue: 0
+            }
+        });
+    }
+}
+
+ScatterplotLayerExt.layerName = 'ScatterplotLayerExt';
+ScatterplotLayerExt.defaultProps = defaultProps;

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -170,7 +170,7 @@ const NetworkMap = forwardRef((props, ref) => {
 
         layers.push(new SubstationLayer({
             id: SUBSTATION_LAYER_PREFIX,
-            data: props.network.getVoltageLevels(),
+            data: props.network.substations,
             network: props.network,
             geoData: props.geoData,
             getNominalVoltageColor: getNominalVoltageColor,

--- a/src/components/network/network.js
+++ b/src/components/network/network.js
@@ -37,12 +37,6 @@ export default class Network {
                 // add substation id
                 voltageLevel.substationId = substation.id;
 
-                // add index in substation
-                voltageLevel.voltageLevelIndex = index;
-
-                // add count in substation
-                voltageLevel.voltageLevelCount = substation.voltageLevels.length;
-
                 // add the current item into the VL map by id
                 this.substationsById.set(substation.id, substation);
 

--- a/src/components/network/substation-layer.js
+++ b/src/components/network/substation-layer.js
@@ -44,14 +44,15 @@ class SubstationLayer extends CompositeLayer {
                 //   - a list of voltage level that belong to same substation and with same nominal voltage
                 //   - index of the voltage levels nominal voltage in the substation nominal voltage list
                 props.data.forEach(substation => {
-                    // index voltage levels of the current substation by its nominal voltage (this is because we might
+                    // index voltage levels of this substation by its nominal voltage (this is because we might
                     // have several voltage levels with the same nominal voltage in the same substation)
                     const voltageLevelsByNominalVoltage = substation.voltageLevels.reduce(voltageLevelNominalVoltageIndexer, new Map());
 
-                    // sorted nominal voltages
+                    // sorted distinct nominal voltages for this substation
                     const nominalVoltages = [...new Set(substation.voltageLevels.map(voltageLevel => voltageLevel.nominalVoltage)
                                                                                 .sort((nominalVoltage1, nominalVoltage2) => nominalVoltage1 - nominalVoltage2))];
 
+                    // add to global map of meta voltage levels indexed by nominal voltage
                     Array.from(voltageLevelsByNominalVoltage.entries())
                         .forEach(e => {
                             const nominalVoltage = e[0];
@@ -70,6 +71,7 @@ class SubstationLayer extends CompositeLayer {
                 });
             }
 
+            // sort the map by descending nominal voltages
             const metaVoltageLevelsByNominalVoltageArray = Array.from(metaVoltageLevelsByNominalVoltage)
                 .map(e => { return {nominalVoltage: e[0], metaVoltageLevels: e[1]}; })
                 .sort((a, b) => b.nominalVoltage - a.nominalVoltage);

--- a/src/components/network/substation-layer.js
+++ b/src/components/network/substation-layer.js
@@ -42,7 +42,6 @@ class SubstationLayer extends CompositeLayer {
                 // create meta voltage levels
                 // a meta voltage level is made of:
                 //   - a list of voltage level that belong to same substation and with same nominal voltage
-                //   - list of distinct nominal voltages of the substation
                 //   - index of the voltage levels nominal voltage in the substation nominal voltage list
                 props.data.forEach(substation => {
                     // index voltage levels of the current substation by its nominal voltage (this is because we might


### PR DESCRIPTION
To avoid substation concentric circles to become to large when zooming in, we limit the max size in pixels of circles.  To do that I had to hack to scatterplot layer that does not allow to have a max pixel size depending on the object (this is a uniform and not an attribute in the GLSL).

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>