### PR TITLE
Correction of the substations list display

### DIFF
--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -286,24 +286,27 @@ const StudyPane = () => {
             }
         }
         return (
-            <Grid container className={classes.main}>
-                <Grid container direction='column' xs={12} md={2} >
+            <Grid container direction='row' className={classes.main}>
+                <Grid item xs={12} md={2} >
                     <AutoSizer>
                         {({width, height}) => (
                             <div style={{width:width, height:height}}>
-                                <Grid item key="loadFlowButton">
-                                    <div style={{position:"relative", marginLeft:8, marginRight:8, marginTop:8}}>
-                                        <RunLoadFlowButton/>
-                                    </div>
+                                <Grid container direction='column'>
+                                    <Grid item key="loadFlowButton">
+                                        <div style={{position:"relative", marginLeft:8, marginRight:8, marginTop:8}}>
+                                            <RunLoadFlowButton/>
+                                        </div>
+                                    </Grid>
+                                    <Grid item key="explorer">
+                                        <div style={{position:"relative", height:height-44}}>
+                                            <NetworkExplorer network={network}
+                                                             onVoltageLevelDisplayClick={showVoltageLevelDiagram}
+                                                             onVoltageLevelFocusClick={centerSubstation} />
+                                        </div>
+                                    </Grid>
                                 </Grid>
-                                <Grid item key="explorer">
-                                    <div style={{position:"relative", height:height-50}}>
-                                        <NetworkExplorer network={network}
-                                                         onVoltageLevelDisplayClick={showVoltageLevelDiagram}
-                                                         onVoltageLevelFocusClick={centerSubstation} />
-                                    </div>
-                                </Grid>
-                            </div>)}
+                            </div>
+                        )}
                     </AutoSizer>
                 </Grid>
                 <Grid item xs={12} md={10} key="map">

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -40,6 +40,7 @@ import Button from "@material-ui/core/Button";
 import PlayIcon from "@material-ui/icons/PlayArrow";
 import { green } from '@material-ui/core/colors';
 import AutoSizer from "react-virtualized/dist/commonjs/AutoSizer";
+import {CardHeader} from "@material-ui/core";
 
 const useStyles = makeStyles(theme => ({
     main: {
@@ -228,6 +229,10 @@ const StudyPane = () => {
                 backgroundColor: green[700],
             },
         },
+        label: {
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+        }
     });
 
     function RunLoadFlowButton() {
@@ -257,7 +262,11 @@ const StudyPane = () => {
                 disabled={loadFlowRunning}
                 onClick={!loadFlowRunning ? handleClick : null}
             >
-                {loadFlowRunning ? 'LoadFlow running…' : 'Start LoadFlow'}
+                <div className={loadFlowButtonClasses.label}>
+                    <Typography noWrap>
+                        {loadFlowRunning ? 'LoadFlow running…' : 'Start LoadFlow'}
+                    </Typography>
+                </div>
             </Button>
         );
     }

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -39,6 +39,7 @@ import NominalVoltageFilter from "./network/nominal-voltage-filter";
 import Button from "@material-ui/core/Button";
 import PlayIcon from "@material-ui/icons/PlayArrow";
 import { green } from '@material-ui/core/colors';
+import AutoSizer from "react-virtualized/dist/commonjs/AutoSizer";
 
 const useStyles = makeStyles(theme => ({
     main: {
@@ -278,16 +279,23 @@ const StudyPane = () => {
         return (
             <Grid container className={classes.main}>
                 <Grid container direction='column' xs={12} md={2} >
-                    <Grid item key="loadFlowButton">
-                        <div style={{position:"relative", marginLeft:8, marginRight:8, marginTop:8}}>
-                            <RunLoadFlowButton/>
-                        </div>
-                    </Grid>
-                    <Grid item key="explorer">
-                        <NetworkExplorer network={network}
-                                         onVoltageLevelDisplayClick={showVoltageLevelDiagram}
-                                         onVoltageLevelFocusClick={centerSubstation} />
-                    </Grid>
+                    <AutoSizer>
+                        {({width, height}) => (
+                            <div style={{width:width, height:height}}>
+                                <Grid item key="loadFlowButton">
+                                    <div style={{position:"relative", marginLeft:8, marginRight:8, marginTop:8}}>
+                                        <RunLoadFlowButton/>
+                                    </div>
+                                </Grid>
+                                <Grid item key="explorer">
+                                    <div style={{position:"relative", height:height-50}}>
+                                        <NetworkExplorer network={network}
+                                                         onVoltageLevelDisplayClick={showVoltageLevelDiagram}
+                                                         onVoltageLevelFocusClick={centerSubstation} />
+                                    </div>
+                                </Grid>
+                            </div>)}
+                    </AutoSizer>
                 </Grid>
                 <Grid item xs={12} md={10} key="map">
                     <div style={{position:"relative", width:"100%", height: "100%"}}>


### PR DESCRIPTION
Correction of the substations list display which displayed only 3 substations after addition of loadflow button

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>