### PR TITLE
fix regression when manipulating network

### DIFF
--- a/src/components/network/line-layer.js
+++ b/src/components/network/line-layer.js
@@ -162,7 +162,7 @@ class LineLayer extends CompositeLayer {
             const lineActivePowerLabelsLayer = new TextLayer(this.getSubLayerProps({
                 id: "ActivePower" + compositeData.nominalVoltage,
                 data: compositeData.activePower,
-                getText: activePower => activePower.p.toString(),
+                getText: activePower => activePower.p !== undefined ? activePower.p.toString() : "",
                 getPosition: activePower => activePower.printPosition,
                 getColor: this.props.labelColor,
                 fontFamily: 'Roboto',


### PR DESCRIPTION
Signed-off-by: AbdelHedhili <abdelsalem.hedhili@rte-france.com>

Loadflow causes an error on the lines' active power label